### PR TITLE
Bugfix/#16: Added validation for transactions in voucher create

### DIFF
--- a/AccountsManager.ApplicationModels/V1/Validators/VoucherValidators/VoucherCreateDTOValidator.cs
+++ b/AccountsManager.ApplicationModels/V1/Validators/VoucherValidators/VoucherCreateDTOValidator.cs
@@ -19,6 +19,10 @@ namespace AccountsManager.ApplicationModels.V1.Validators.VoucherValidators
 
             RuleForEach(x => x.Transactions)
                 .SetValidator(new TransactionCreateValidator());
+
+            RuleFor(x => x.Transactions)
+                .Must(m => m.Count >= 2)
+                .WithMessage("Vocuher must contain atleast one transaction for credit and one for debt.");
         }
     }
 }


### PR DESCRIPTION
Added one more rule to voucher createDTO validator. Voucher must contain at least two transactions now: one for credit account and one for debt account